### PR TITLE
Arch linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ ./install.sh
 - Installs system dependencies.
 - Installs necessary [Fred's ImageMagick Scripts](http://www.fmwconcepts.com/imagemagick/) into the `./lib` directory.
 
-> **Note:** Only [Homebrew](http://brew.sh/) and [openSUSE](https://www.opensuse.org/) are supported as of now. Feel free to contribute installation of dependencies with your favorite package manager, e.g. `apt-get`.
+> **Note:** Only [Homebrew](http://brew.sh/), [openSUSE](https://www.opensuse.org/) and [Arch Linux](https://www.archlinux.org/) are supported as of now. Feel free to contribute installation of dependencies with your favorite package manager, e.g. `apt-get`.
 
 ## Usage
 

--- a/dependencies/os-linux.txt
+++ b/dependencies/os-linux.txt
@@ -1,0 +1,8 @@
+bc
+coreutils
+gawk
+grep
+imagemagick
+potrace
+sed
+wget

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ elif grep '^ID=.*opensuse' /etc/os-release > /dev/null; then
   # the package names happen to work
   sudo zypper install $(cat ./dependencies/os-brew.txt)
 elif grep '^ID=arch' /etc/os-release > /dev/null; then
-  sudo pacman -S --needed $(cat ./dependencies/os-brew.txt)
+  sudo pacman -S --needed $(cat ./dependencies/os-linux.txt)
 else
   echo 'Unsupported OS.'
   exit 1

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ if [ "$(uname)" = "Darwin" ]; then
 elif grep '^ID=.*opensuse' /etc/os-release > /dev/null; then
   # the package names happen to work
   sudo zypper install $(cat ./dependencies/os-brew.txt)
+elif grep '^ID=arch' /etc/os-release > /dev/null; then
+  sudo pacman -S --needed $(cat ./dependencies/os-brew.txt)
 else
   echo 'Unsupported OS.'
   exit 1


### PR DESCRIPTION
Added support for Arch Linux.

Those _Fred's ImageMagick Scripts_ use several commands not present on every system (e.g. mine is without `bc`) so I created new dependencies list and used it in the Arch Linux branch of install.sh script.
It should work in openSUSE too (found all packages on https://rpmfind.net/linux/rpm2html/search.php?system=opensuse&arch=x86_64) but as I don't use this distro I do not dare to modify its "else" branch in the installer.
